### PR TITLE
fixes #18 : create react app public directory

### DIFF
--- a/generators/REACT_SCRIPTS/index.js
+++ b/generators/REACT_SCRIPTS/index.js
@@ -8,7 +8,7 @@ var packageJson = helpers.getPackageJson();
 
 // TODO: Get the latest version of storybook here.
 packageJson.devDependencies['@kadira/storybook'] = '^2.5.2';
-packageJson.scripts['storybook'] = 'start-storybook -p 9009';
+packageJson.scripts['storybook'] = 'start-storybook -p 9009 -s public';
 packageJson.scripts['build-storybook'] = 'build-storybook';
 
 helpers.writePackageJson(packageJson);


### PR DESCRIPTION
fixes #18 
use `/public` directory as default static directory for create react app based apps as this is the default for create react app
