### PR TITLE
Fix link to custom webpack config docs

### DIFF
--- a/generators/WEBPACK_REACT/template/.storybook/webpack.config.js
+++ b/generators/WEBPACK_REACT/template/.storybook/webpack.config.js
@@ -1,6 +1,6 @@
 // you can use this file to add your custom webpack plugins, loaders and anything you like.
 // This is just the basic way to add addional webpack configurations.
-// For more information refer the docs: https://goo.gl/qPbSyX
+// For more information refer the docs: https://getstorybook.io/docs/configurations/custom-webpack-config
 
 // IMPORTANT
 // When you add this file, we won't add the default configurations which is similar


### PR DESCRIPTION
https://goo.gl/qPbSyX currently points at https://github.com/kadirahq/react-storybook/blob/master/docs/configure_storybook.md#custom-webpack-configurations which is a 404.

You may want to re-apply your url shortener to this.
