### PR TITLE
Fix installation of dependencies on Windows

### DIFF
--- a/lib/has_yarn.js
+++ b/lib/has_yarn.js
@@ -1,4 +1,4 @@
-var spawnSync = require('spawn-sync');
+var spawnSync = require('cross-spawn').sync;
 
 module.exports = function hasYarn() {
   var result = spawnSync('yarn', ['--version'], { silent: true });

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,7 +2,7 @@ var path = require('path');
 var fs = require('fs');
 var chalk = require('chalk');
 var logger = console;
-var spawnSync = require('spawn-sync');
+var spawnSync = require('cross-spawn').sync;
 
 exports.getPackageJson = function getPackageJson() {
   var packageJsonPath = path.resolve('package.json');

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
+    "cross-spawn": "^5.0.1",
     "json5": "^0.5.0",
     "merge-dirs": "^0.2.1",
     "shelljs": "^0.7.3",
-    "spawn-sync": "^1.0.15",
     "update-notifier": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The `npm install` step was failing with an ENOENT error, which cross-spawn fixes.